### PR TITLE
Fix: Gamepads didn't actually work?

### DIFF
--- a/src/System/Input.c
+++ b/src/System/Input.c
@@ -89,6 +89,8 @@ static inline void UpdateKeyState(KeyState* state, bool downNow)
 
 void InitInput(void)
 {
+	// Open a connected gamepad on startup.
+	TryOpenGamepad(false);
 }
 
 void UpdateInput(void)
@@ -477,6 +479,7 @@ SDL_Gamepad* TryOpenGamepad(bool showMessage)
 		newGamepad = SDL_OpenGamepad(joystickID);
 		if (newGamepad)
 		{
+			gSDLGamepad = newGamepad;
 			break;
 		}
 	}
@@ -576,7 +579,7 @@ static OGLVector2D GetThumbStickVector(bool rightStick)
 	else
 	{
 		float magnitude;
-		
+
 		if (magnitudeSquared > 1.0f)
 		{
 			// Cap magnitude -- what's returned by the controller actually lies within a square

--- a/src/System/Input.c
+++ b/src/System/Input.c
@@ -90,7 +90,7 @@ static inline void UpdateKeyState(KeyState* state, bool downNow)
 void InitInput(void)
 {
 	// Open a connected gamepad on startup.
-	TryOpenGamepad(false);
+	TryOpenGamepad(true);
 }
 
 void UpdateInput(void)


### PR DESCRIPTION
This PR is a nothingburger, I just tried to play on my Mac and noticed my gamepad wasn't being picked up.

A better fix for this later would be to open any available gamepads and take inputs from any of them, lots of other niceties one could do, but this at least gets _a_ connected gamepad working. :)

Thank you for putting in all the time and effort to create these ports. These games were a big part of my childhood, and part of the reason I'm a game developer today.